### PR TITLE
Update abelsiqueira/COPIERTemplate.jl to JuliaBesties/BestieTemplate.jl

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -11,4 +11,4 @@ PackageUUID: a88418a5-8dc5-4f1c-8a3e-d5a75ec49c70
 RunJuliaNightlyOnCI: false
 UseCirrusCI: false
 _commit: v0.2.5
-_src_path: https://github.com/abelsiqueira/COPIERTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
